### PR TITLE
Overflow is bad :p

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,7 +15,6 @@ body {
     font-family: 'Roboto', sans-serif;
     margin: 0;
     padding: 0;
-    overflow-x: hidden;
 }
 
 .projectLink {
@@ -24,7 +23,6 @@ body {
 
 .block {
     padding-top: 1em;
-    width: 100vw;
 }
 
 .bluebg {


### PR DESCRIPTION
LehrerLupus here :)

Simplement car l'overflow c'est sale :p
(ca casse rien, testé sous chrome, edge, firefox)

**Explication du code :**
Les `div` sont par défaut des élements de type `block`, donc elles prennent la taille disponible du parent.
Sachant que `.block` dépend du `body`, pas besoin de setter la `width` :), ***TADAM !***

Dis moi si tu veux un fix pour l'animation sur firefox, ou si tu veux garder la version JS avec un fix de ta part :)
With love and 🍵 